### PR TITLE
Hide unused iOS var for other platforms

### DIFF
--- a/Assets/Editor/AdjustEditor.cs
+++ b/Assets/Editor/AdjustEditor.cs
@@ -11,8 +11,9 @@ using UnityEditor.Callbacks;
 public class AdjustEditor : MonoBehaviour
 {
 	static bool isEnabled = true;
+		#if UNITY_IOS
 	static string iOSBuildPath = "";
-
+		#endif
 	[PostProcessBuild]
 	public static void OnPostprocessBuild (BuildTarget target, string pathToBuiltProject)
 	{


### PR DESCRIPTION
Some tiny improvement, removing an unwanted UnityEditor warning.