### PR TITLE
UPM support fix

### DIFF
--- a/Assets/Adjust/Editor/AdjustEditorPreprocessor.cs
+++ b/Assets/Adjust/Editor/AdjustEditorPreprocessor.cs
@@ -44,7 +44,7 @@ public class AdjustEditorPreprocessor : IPreprocessBuild
     {
         var isAdjustManifestUsed = false;
         var androidPluginsPath = Path.Combine(Application.dataPath, "Plugins/Android");
-        var adjustManifestPath = Path.Combine(Application.dataPath, "Adjust/Android/AdjustAndroidManifest.xml");
+        var adjustManifestPath =  "Packages/com.adjust.sdk/Android/AdjustAndroidManifest.xml";
         var appManifestPath = Path.Combine(Application.dataPath, "Plugins/Android/AndroidManifest.xml");
 
         // Check if user has already created AndroidManifest.xml file in its location.


### PR DESCRIPTION
Replaced absolute path to the assets folder with relative path to the packages folder

Unity uses virtual file system for install UPM packages. We can be sure that package files can be accessed from "Packages/name of the package/" directory