### PR TITLE
Use CODE_SIGN_ENTITLEMENTS value if the value exists.

### DIFF
--- a/Assets/Adjust/Scripts/Editor/AdjustEditor.cs
+++ b/Assets/Adjust/Scripts/Editor/AdjustEditor.cs
@@ -310,7 +310,11 @@ namespace AdjustSdk
 
         private static void AddUniversalLinkDomains(PBXProject project, string xCodeProjectPath, string xCodeTarget)
         {
-            string entitlementsFileName = "Unity-iPhone.entitlements";
+            string entitlementsFileName = project.GetBuildPropertyForAnyConfig(xCodeTarget, "CODE_SIGN_ENTITLEMENTS");
+            if (entitlementsFileName == null)
+            {
+                entitlementsFileName = "Unity-iPhone.entitlements";
+            }
 
             Debug.Log("[Adjust]: Adding associated domains to entitlements file.");
     #if UNITY_2019_3_OR_NEWER


### PR DESCRIPTION
In the project I am involved in, the value of CODE_SIGN_ENTITLEMENTS is set other value instead of “Unity-iPhone.entitlements”.
To export Adjust settings to a file set to CODE_SIGN_ENTITLEMENTS I want to make changes to the PR.
